### PR TITLE
fix: Update set-env and add-path to use Environment Files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,17 +232,20 @@ jobs:
       # Invoke-ActionNoCommandsBlock
       - name: Invoke-ActionNoCommandsBlock test (act)
         uses: ./
+        id: Invoke-ActionNoCommandsBlock
+        continue-on-error: true
         with:
           script: |
             Invoke-ActionNoCommandsBlock -GenerateToken {
-              Set-ActionVariable nocmdvar nocmd
+              Write-ActionError error-msg
             }
       - name: Invoke-ActionNoCommandsBlock test (assert)
         uses: ./
         with:
           script: |
-            if ($env:nocmdvar -ne $null) {
-              throw "Invoke-ActionNoCommandsBlock failed.`n$env:nocmdvar"
+            $result = '${{ steps.Invoke-ActionNoCommandsBlock.outcome }}'
+            if ($result -ne 'failure') {
+              throw "Invoke-ActionNoCommandsBlock failed.`n$result"
             }
 
       # Write-Action -Debug, -Info, -Warning, -Error and Grouping are not testable in any sensible manner

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,7 +243,7 @@ jobs:
         with:
           script: |
             $result = '${{ steps.Invoke-ActionNoCommandsBlock.outputs.testout }}'
-            if ($result -cne 'testval') {
+            if ($result) {
               throw "Invoke-ActionNoCommandsBlock failed.`n$result"
             }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,20 +231,19 @@ jobs:
 
       # Invoke-ActionNoCommandsBlock
       - name: Invoke-ActionNoCommandsBlock test (act)
-        uses: ./
         id: Invoke-ActionNoCommandsBlock
-        continue-on-error: true
-        with:
-          script: |
+        shell: pwsh
+        run: |
+            Import-Module ./lib/GitHubActionsCore -Force
             Invoke-ActionNoCommandsBlock -GenerateToken {
-              Write-ActionError error-msg
+              Set-ActionOutput testout testval
             }
       - name: Invoke-ActionNoCommandsBlock test (assert)
         uses: ./
         with:
           script: |
-            $result = '${{ steps.Invoke-ActionNoCommandsBlock.outcome }}'
-            if ($result -ne 'failure') {
+            $result = '${{ steps.Invoke-ActionNoCommandsBlock.outputs.testout }}'
+            if ($result -cne 'testval') {
               throw "Invoke-ActionNoCommandsBlock failed.`n$result"
             }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Test with Pester
-        run: |
-          Install-Module -Name Pester -Force -SkipPublisherCheck -MinimumVersion '5.0'
-          Import-Module Pester -MinimumVersion '5.0'
-          Invoke-Pester -CI
+        run: ./test.ps1
       - name: Invoke action
         env:
           TEMP: ${{ runner.temp }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- `Send-ActionFileCommand` cmdlet that handles sending commands to [Environment Files] instead of console output ([#8]).
+
+### Changed
+- `Add-ActionPath` and `Set-ActionVariable` are updated for [Environment Files] Actions Runner change ([#8]).
+
+[Environment Files]: https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#environment-files
+[#8]: https://github.com/Amadevus/pwsh-script/pull/8
+
 ## [2.0.0] - 2020-09-10
 
 ### Changed

--- a/docs/GitHubActionsCore/README.md
+++ b/docs/GitHubActionsCore/README.md
@@ -9,6 +9,7 @@
 | [Invoke-ActionGroup](Invoke-ActionGroup.md) | Executes the argument script block within an output group. Equivalent of `core.group(name, func)`. |
 | [Invoke-ActionNoCommandsBlock](Invoke-ActionNoCommandsBlock.md) | Invokes a scriptblock that won't result in any output interpreted as a workflow command. Useful for printing arbitrary text that may contain command-like text. No quivalent in `@actions/core` package. |
 | [Send-ActionCommand](Send-ActionCommand.md) | Sends a command to the hosting Workflow/Action context. Equivalent to `core.issue(cmd, msg)`/`core.issueCommand(cmd, props, msg)`. |
+| [Send-ActionFileCommand](Send-ActionFileCommand.md) | Sends a command to an Action Environment File. Equivalent to `core.issueFileCommand(cmd, msg)`. |
 | [Set-ActionCommandEcho](Set-ActionCommandEcho.md) | Enables or disables the echoing of commands into stdout for the rest of the step. Echoing is disabled by default if ACTIONS_STEP_DEBUG is not set. Equivalent of `core.setCommandEcho(enabled)`. |
 | [Set-ActionFailed](Set-ActionFailed.md) | Sets an action status to failed. When the action exits it will be with an exit code of 1. Equivalent of `core.setFailed(message)`. |
 | [Set-ActionOutput](Set-ActionOutput.md) | Sets the value of an output. Equivalent of `core.setOutput(name, value)`. |

--- a/docs/GitHubActionsCore/Send-ActionFileCommand.md
+++ b/docs/GitHubActionsCore/Send-ActionFileCommand.md
@@ -1,0 +1,72 @@
+# Send-ActionFileCommand
+```
+
+NAME
+    Send-ActionFileCommand
+    
+SYNOPSIS
+    Sends a command to an Action Environment File.
+    Equivalent to `core.issueFileCommand(cmd, msg)`.
+    
+    
+SYNTAX
+    Send-ActionFileCommand [-Command] <String> [-Message] <PSObject> [<CommonParameters>]
+    
+    
+DESCRIPTION
+    Appends given message to an Action Environment File.
+    
+
+PARAMETERS
+    -Command <String>
+        Command (environment file variable suffix) to send message for.
+        
+        Required?                    true
+        Position?                    1
+        Default value                
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+        
+    -Message <PSObject>
+        Message to append.
+        
+        Required?                    true
+        Position?                    2
+        Default value                
+        Accept pipeline input?       true (ByValue)
+        Accept wildcard characters?  false
+        
+    <CommonParameters>
+        This cmdlet supports the common parameters: Verbose, Debug,
+        ErrorAction, ErrorVariable, WarningAction, WarningVariable,
+        OutBuffer, PipelineVariable, and OutVariable. For more information, see
+        about_CommonParameters (https://go.microsoft.com/fwlink/?LinkID=113216). 
+    
+INPUTS
+    
+OUTPUTS
+    
+    -------------------------- EXAMPLE 1 --------------------------
+    
+    PS>Send-ActionFileCommand ENV 'myvar=value'
+    
+    
+    
+    
+    
+    
+    -------------------------- EXAMPLE 2 --------------------------
+    
+    PS>'myvar=value', 'myvar2=novalue' | Send-ActionFileCommand ENV
+    
+    
+    
+    
+    
+    
+    
+RELATED LINKS
+    https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#environment-files
+
+```
+

--- a/lib/GitHubActionsCore/GitHubActionsCore.Tests.ps1
+++ b/lib/GitHubActionsCore/GitHubActionsCore.Tests.ps1
@@ -154,7 +154,7 @@ Describe 'Add-ActionPath' {
     BeforeEach {
         [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'Used in AfterEach')]
         $prevPath = [System.Environment]::GetEnvironmentVariable('PATH')
-        
+
         [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'Used in AfterEach')]
         $oldGithubPath = $env:GITHUB_PATH
         Remove-Item Env:GITHUB_PATH -ea:Ignore
@@ -450,7 +450,7 @@ Describe 'Send-ActionFileCommand' {
     }
     Context 'When file exists' {
         BeforeAll {
-            Mock Test-Path { return $true } -ModuleName GitHubActionsCore
+            Mock Test-Path { $true } -ModuleName GitHubActionsCore
             Mock Out-File { } -ModuleName GitHubActionsCore
         }
         BeforeEach {
@@ -475,7 +475,7 @@ Describe 'Send-ActionFileCommand' {
             } -ModuleName GitHubActionsCore
         }
         AfterEach {
-            Remove-Item env:GITHUB_TEST -ea:Ignore
+            Remove-Item env:GITHUB_TESTCMD -ea:Ignore
         }
     }
 }

--- a/lib/GitHubActionsCore/GitHubActionsCore.Tests.ps1
+++ b/lib/GitHubActionsCore/GitHubActionsCore.Tests.ps1
@@ -77,7 +77,7 @@ Describe 'Set-ActionVariable' {
     BeforeEach {
         [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'Used in AfterEach')]
         $oldGithubEnv = $env:GITHUB_ENV
-        Remove-Item Env:GITHUB_ENV -ea:Ignore
+        $env:GITHUB_ENV = $null
     }
     AfterEach {
         $env:GITHUB_ENV = $oldGithubEnv
@@ -157,7 +157,7 @@ Describe 'Add-ActionPath' {
 
         [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'Used in AfterEach')]
         $oldGithubPath = $env:GITHUB_PATH
-        Remove-Item Env:GITHUB_PATH -ea:Ignore
+        $env:GITHUB_PATH = $null
     }
     AfterEach {
         [System.Environment]::SetEnvironmentVariable('PATH', $prevPath)
@@ -212,9 +212,6 @@ Describe 'Add-ActionPath' {
                 $InputObject -eq 'test path'
             } -ModuleName GitHubActionsCore
         }
-        AfterEach {
-            Remove-Item Env:GITHUB_PATH -ea:Ignore
-        }
     }
 }
 Describe 'Set-ActionCommandEcho' {
@@ -259,9 +256,14 @@ Describe 'Set-ActionFailed' {
 Describe 'Get-ActionIsDebug' {
     BeforeAll {
         Mock Write-Host { } -ModuleName GitHubActionsCore
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'Used in AfterAll')]
+        $oldEnvRunnerDebug = $env:RUNNER_DEBUG
+    }
+    AfterAll {
+        $env:RUNNER_DEBUG = $oldEnvRunnerDebug
     }
     BeforeEach {
-        Remove-Item Env:RUNNER_DEBUG -ErrorAction SilentlyContinue
+        $env:RUNNER_DEBUG = $null
     }
     It 'Given env var is not set, return false' {
         $result = Get-ActionIsDebug
@@ -281,9 +283,6 @@ Describe 'Get-ActionIsDebug' {
         $result = Get-ActionIsDebug
         
         $result | Should -BeExactly $Expected
-    }
-    AfterEach {
-        Remove-Item Env:RUNNER_DEBUG -ErrorAction SilentlyContinue
     }
 }
 Describe 'Write-ActionError' {
@@ -436,7 +435,7 @@ Describe 'Send-ActionFileCommand' {
         } | Should -Throw "Cannot validate argument on parameter 'Command'. The argument is null or empty.*"
     }
     It "Given command for which env var doesn't exist" {
-        Remove-Item env:GITHUB_FOO -ea:Ignore
+        $env:GITHUB_FOO = $null
         {
             Send-ActionFileCommand -Command FOO -Message 'foobar'
         } | Should -Throw 'Unable to find environment variable for file command FOO'
@@ -446,7 +445,7 @@ Describe 'Send-ActionFileCommand' {
         {
             Send-ActionFileCommand -Command FOO -Message 'foobar'
         } | Should -Throw 'Missing file at path: *foo.bar'
-        Remove-Item env:GITHUB_FOO -ea:Ignore
+        $env:GITHUB_FOO = $null
     }
     Context 'When file exists' {
         BeforeAll {
@@ -475,7 +474,7 @@ Describe 'Send-ActionFileCommand' {
             } -ModuleName GitHubActionsCore
         }
         AfterEach {
-            Remove-Item env:GITHUB_TESTCMD -ea:Ignore
+            $env:GITHUB_TESTCMD = $null
         }
     }
 }

--- a/lib/GitHubActionsCore/GitHubActionsCore.Tests.ps1
+++ b/lib/GitHubActionsCore/GitHubActionsCore.Tests.ps1
@@ -218,6 +218,8 @@ Describe 'Set-ActionCommandEcho' {
 }
 Describe 'Set-ActionFailed' {
     BeforeAll {
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'Used in AfterAll')]
+        $oldExitCode = [System.Environment]::ExitCode
         Mock Write-Host { } -ModuleName GitHubActionsCore
     }
     BeforeEach {
@@ -236,8 +238,8 @@ Describe 'Set-ActionFailed' {
             $Object -eq "::error::$Expected"
         } -ModuleName GitHubActionsCore
     }
-    AfterEach {
-        [System.Environment]::ExitCode = 0
+    AfterAll {
+        [System.Environment]::ExitCode = $oldExitCode
     }
 }
 Describe 'Get-ActionIsDebug' {
@@ -246,11 +248,11 @@ Describe 'Get-ActionIsDebug' {
         [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'Used in AfterAll')]
         $oldEnvRunnerDebug = $env:RUNNER_DEBUG
     }
-    AfterAll {
-        $env:RUNNER_DEBUG = $oldEnvRunnerDebug
-    }
     BeforeEach {
         $env:RUNNER_DEBUG = $null
+    }
+    AfterAll {
+        $env:RUNNER_DEBUG = $oldEnvRunnerDebug
     }
     It 'Given env var is not set, return false' {
         $result = Get-ActionIsDebug
@@ -458,7 +460,7 @@ Describe 'Send-ActionFileCommand' {
             @{ Msg = "a `r `n b : c % d"; Expected = $null }
             @{ Msg = 1; Expected = $null }
             @{ Msg = $true; Expected = 'true' }
-            @{ Msg = @{ a = 1; b = $false }; Expected = '{"a":1,"b":false}' }
+            @{ Msg = [ordered]@{ a = 1; b = $false }; Expected = '{"a":1,"b":false}' }
         ) {
             Send-ActionFileCommand TESTCMD -Message $Msg
 

--- a/lib/GitHubActionsCore/GitHubActionsCore.psm1
+++ b/lib/GitHubActionsCore/GitHubActionsCore.psm1
@@ -554,7 +554,8 @@ function Send-ActionCommand {
 
 <#
 .SYNOPSIS
-Sends message to an Action Environment File.
+Sends a command to an Action Environment File.
+Equivalent to `core.issueFileCommand(cmd, msg)`.
 .DESCRIPTION
 Appends given message to an Action Environment File.
 .PARAMETER Command

--- a/lib/GitHubActionsCore/GitHubActionsCore.psm1
+++ b/lib/GitHubActionsCore/GitHubActionsCore.psm1
@@ -37,15 +37,23 @@ function Set-ActionVariable {
         [switch]$SkipLocal
     )
     $convertedValue = ConvertTo-ActionCommandValue $Value
-    ## To take effect only in the current action/step
+    ## To take effect in the current action/step
     if (-not $SkipLocal) {
         [System.Environment]::SetEnvironmentVariable($Name, $convertedValue)
     }
 
     ## To take effect for all subsequent actions/steps
-    Send-ActionCommand set-env @{
-        name = $Name
-    } -Message $convertedValue
+    if ($env:GITHUB_ENV) {
+        $delimiter = '_GitHubActionsFileCommandDelimeter_'
+        $eol = [System.Environment]::NewLine
+        $commandValue = "$name<<${delimiter}${eol}${convertedValue}${eol}${delimiter}"
+        Send-ActionFileCommand -Command ENV -Message $commandValue
+    }
+    else {
+        Send-ActionCommand set-env @{
+            name = $Name
+        } -Message $convertedValue
+    }
 }
 
 <#
@@ -93,7 +101,7 @@ function Add-ActionPath {
         [switch]$SkipLocal
     )
 
-    ## To take effect only in the current action/step
+    ## To take effect in the current action/step
     if (-not $SkipLocal) {
         $oldPath = [System.Environment]::GetEnvironmentVariable('PATH')
         $newPath = "$Path$([System.IO.Path]::PathSeparator)$oldPath"
@@ -101,7 +109,12 @@ function Add-ActionPath {
     }
 
     ## To take effect for all subsequent actions/steps
-    Send-ActionCommand add-path $Path
+    if ($env:GITHUB_PATH) {
+        Send-ActionFileCommand -Command PATH -Message $Path
+    }
+    else {
+        Send-ActionCommand -Command add-path -Message $Path
+    }
 }
 
 ## Used to identify inputs from env vars in Action/Workflow context
@@ -539,6 +552,46 @@ function Send-ActionCommand {
     Write-Host $cmdStr
 }
 
+<#
+.SYNOPSIS
+Sends message to an Action Environment File.
+.DESCRIPTION
+Appends given message to an Action Environment File.
+.PARAMETER Command
+Command (environment file variable suffix) to send message for.
+.PARAMETER Message
+Message to append.
+.EXAMPLE
+PS> Send-ActionFileCommand ENV 'myvar=value'
+.EXAMPLE
+PS> 'myvar=value', 'myvar2=novalue' | Send-ActionFileCommand ENV
+.LINK
+https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#environment-files
+#>
+function Send-ActionFileCommand {
+    [CmdletBinding()]
+    param (
+        [Parameter(Position = 0, Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Command,
+
+        [Parameter(Position = 1, Mandatory, ValueFromPipeline)]
+        [psobject]$Message
+    )
+    begin {
+        $filePath = [System.Environment]::GetEnvironmentVariable("GITHUB_$Command")
+        if (-not $filePath) {
+            throw "Unable to find environment variable for file command $Command"
+        }
+        if (-not (Test-Path $filePath -PathType Leaf)) {
+            throw "Missing file at path: $filePath"
+        }
+    }
+    process {
+        ConvertTo-ActionCommandValue $Message | Out-File -FilePath $filePath -Append
+    }
+}
+
 ###########################################################################
 ## Internal Implementation
 ###########################################################################
@@ -669,6 +722,7 @@ Get-ActionIsDebug,
 Invoke-ActionGroup,
 Invoke-ActionNoCommandsBlock,
 Send-ActionCommand,
+Send-ActionFileCommand,
 Set-ActionCommandEcho,
 Set-ActionFailed,
 Set-ActionOutput,

--- a/test.ps1
+++ b/test.ps1
@@ -1,0 +1,12 @@
+[CmdletBinding()]
+param (
+    [Parameter()]
+    [switch]
+    $CI = ($env:CI -eq 'true')
+)
+
+if (Get-Module Pester | ? Version -LT '5.1') {
+    Install-Module -Name Pester -Force -SkipPublisherCheck -MinimumVersion '5.1' -PassThru
+        | Import-Module Pester -MinimumVersion '5.1'
+}
+Invoke-Pester -CI:$CI


### PR DESCRIPTION
Actions runners will mark as warning using these old commands,
instead these should write to special env files

per https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

fixes #6