### PR TITLE
fix: correctly handle multiline values in Set-ActionOutput

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,6 +193,8 @@ jobs:
           script: |
             $props = [ordered]@{ a = 1; b = 'c' }
             Set-ActionVariable testvar $props
+            Set-ActionVariable testvar_multiline "line1`nline2`nline3"
+            Get-Content $env:GITHUB_ENV -Raw | Write-Host
             if ($env:testvar -cne '{"a":1,"b":"c"}') {
               throw "unexpected: Set-ActionVariable failed.`n$env:testvar"
             }
@@ -202,6 +204,9 @@ jobs:
           script: |
             if ($env:testvar -cne '{"a":1,"b":"c"}') {
               throw "unexpected: Set-ActionVariable failed.`n$env:testvar"
+            }
+            if ($env:testvar_multiline -cne "line1`nline2`nline3") {
+              throw "unexpected: Set-ActionVariable failed.`n$env:testvar_multiline"
             }
 
       # Set-ActionCommandEcho

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+* fix: correctly handle multiline values in Set-ActionOutput and Set-ActionVariable.
+
 ## [2.0.2] - 2022-10-17
 
 ### Changed

--- a/lib/GitHubActionsCore/GitHubActionsCore.Tests.ps1
+++ b/lib/GitHubActionsCore/GitHubActionsCore.Tests.ps1
@@ -62,7 +62,7 @@ Describe 'Set-ActionOutput' {
     Context "Given value '<value>'" -Foreach @(
         @{ Value = ''; ExpectedCmd = ''; ExpectedEnv = $null }
         @{ Value = 'test value'; ExpectedCmd = 'test value'; ExpectedEnv = 'test value' }
-        @{ Value = "test `n multiline `r`n value"; ExpectedCmd = 'test %0A multiline %0D%0A value'; ExpectedEnv = "test `n multiline `r`n value" }
+        @{ Value = "test `n multiline `r`n value"; ExpectedCmd = 'test %0A multiline %0D%0A value'; ExpectedEnv = "test `n multiline `r`n value"; Multiline = $true }
         @{ Value = 'A % B'; ExpectedCmd = 'A %25 B'; ExpectedEnv = 'A % B' }
         @{ Value = [ordered]@{ a = '1x'; b = '2y' }; ExpectedCmd = '{"a":"1x","b":"2y"}'; ExpectedEnv = '{"a":"1x","b":"2y"}' }
     ) {
@@ -88,7 +88,7 @@ Describe 'Set-ActionOutput' {
                 Set-ActionOutput 'my-result' $Value
         
                 $eol = [System.Environment]::NewLine
-                if ($ExpectedEnv -contains "`n") {
+                if ($Multiline) {
                     $null, $delimiter = (Get-Content $testPath)[0] -split "<<"
                     Get-Content $testPath -Raw
                     | Should -BeExactly "my-result<<$delimiter${eol}$ExpectedEnv${eol}$delimiter${eol}"
@@ -131,7 +131,7 @@ Describe 'Set-ActionVariable' {
     Context "Given value '<value>'" -Foreach @(
         @{ Value = ''; ExpectedCmd = ''; ExpectedEnv = $null }
         @{ Value = 'test value'; ExpectedCmd = 'test value'; ExpectedEnv = 'test value' }
-        @{ Value = "test `n multiline `r`n value"; ExpectedCmd = 'test %0A multiline %0D%0A value'; ExpectedEnv = "test `n multiline `r`n value" }
+        @{ Value = "test `n multiline `r`n value"; ExpectedCmd = 'test %0A multiline %0D%0A value'; ExpectedEnv = "test `n multiline `r`n value"; Multiline = $true }
         @{ Value = 'A % B'; ExpectedCmd = 'A %25 B'; ExpectedEnv = 'A % B' }
         @{ Value = [ordered]@{ a = '1x'; b = '2y' }; ExpectedCmd = '{"a":"1x","b":"2y"}'; ExpectedEnv = '{"a":"1x","b":"2y"}' }
     ) {
@@ -167,7 +167,7 @@ Describe 'Set-ActionVariable' {
         
                 $env:TESTVAR | Should -Be $ExpectedEnv
                 $eol = [System.Environment]::NewLine
-                if ($ExpectedEnv -contains "`n") {
+                if ($Multiline) {
                     $null, $delimiter = (Get-Content $testPath)[0] -split "<<"
                     Get-Content $testPath -Raw
                     | Should -BeExactly "TESTVAR<<$delimiter${eol}$ExpectedEnv${eol}$delimiter${eol}"
@@ -182,7 +182,7 @@ Describe 'Set-ActionVariable' {
         
                 $env:TESTVAR | Should -BeNullOrEmpty
                 $eol = [System.Environment]::NewLine
-                if ($ExpectedEnv -contains "`n") {
+                if ($Multiline) {
                     $null, $delimiter = (Get-Content $testPath)[0] -split "<<"
                     Get-Content $testPath -Raw
                     | Should -BeExactly "TESTVAR<<$delimiter${eol}$ExpectedEnv${eol}$delimiter${eol}"

--- a/lib/GitHubActionsCore/GitHubActionsCore.psm1
+++ b/lib/GitHubActionsCore/GitHubActionsCore.psm1
@@ -678,7 +678,7 @@ function ConvertTo-ActionKeyValueFileCommand {
         [object]$Value
     )
     $convertedValue = ConvertTo-ActionCommandValue $Value
-    if (-not ($convertedValue -contains "`n")) {
+    if ($convertedValue -notmatch '\n') {
         return "$Name=$convertedValue"
     }
     $delimiter = "ghadelimiter_$(New-Guid)"


### PR DESCRIPTION
by extension, also Set-ActionVariable is fixed,
as it has silently suffered from the same issue
since last update.

fixes #17